### PR TITLE
修复一处 API 地址错误的问题，并添加“播放全部” 按钮的事件响应

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,6 @@
 // const _baseUrl = 'http://192.168.0.73:809/api/music'
 const _baseUrl = 'http://musicapi.duapp.com/api.php'
-const _baseUrl2 = 'https://api.imjad.cn/cloudmusic'
+const _baseUrl2 = 'https://api.imjad.cn/cloudmusic/'
 export default {
   getPlayListByWhere (cat, order, offset, total, limit) {
     return _baseUrl + '?type=topPlayList&cat=' + cat + '&offset=' + offset + '&limit=' + limit

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -122,18 +122,21 @@ const store = new Vuex.Store({
       }
       state.audio = state.songList[state.currentIndex - 1]
     },
-    addToList (state, item) {
-      var flag = false
-      state.songList.forEach(function (element, index) { // 检测歌曲重复
-        if (element.id === item.id) {
-          flag = true
-          state.currentIndex = index + 1
+    addToList (state, songs) {
+      var items = Array.prototype.concat.call(songs)
+      items.forEach(item => {
+        var flag = false
+        state.songList.forEach(function (element, index) { // 检测歌曲重复
+          if (element.id === item.id) {
+            flag = true
+            state.currentIndex = index + 1
+          }
+        })
+        if (!flag) {
+          state.songList.push(item)
+          state.currentIndex = state.songList.length
         }
       })
-      if (!flag) {
-        state.songList.push(item)
-        state.currentIndex = state.songList.length
-      }
     },
     setLrc (state, lrc) {
       state.lyric = lrc

--- a/src/views/playListDetail.vue
+++ b/src/views/playListDetail.vue
@@ -27,7 +27,7 @@
         </div>
         <div class="playlist-holder">
             <div class="add-all">
-                <mu-flat-button label="播放全部" class="demo-flat-button" icon="add_circle_outline"/>
+                <mu-flat-button label="播放全部" class="demo-flat-button" icon="add_circle_outline" @click="playAll"/>
                 <mu-divider/>
             </div>
             <div>
@@ -120,6 +120,21 @@ export default {
       // 通过Vuex改变状态
       this.$store.commit('addToList', audio)
       this.$store.dispatch('getSong', audio.id)
+    },
+    // 播放全部
+    playAll () {
+      // 添加专辑内所有歌曲到一个新数组
+      let items = []
+
+      this.list.forEach((item) => {
+        items.push({
+          albumPic: item.al.picUrl,
+          id: item.id,
+          name: item.al.name,
+          singer: item.ar[0].name
+        })
+      })
+      this.$store.commit('addToList', items)
     }
   },
   filters: {


### PR DESCRIPTION
目前播放全部功能尚不可用，只是把播放列表添加进去了，但并不能实现播放。

看了下 vuex 中数据结构的定义发现一处问题：歌曲的 location 只能用另一个接口获取，而现在的结构要求在添加音乐的时候就获取 location。所以这一块是否应该修改为在播放的时候获取 location，而不是在添加到列表时获取，获取过的 location 缓存在列表里面，或者用另一个对象维护歌曲 ID 与 location 的对应关系。